### PR TITLE
explicitly remove global transforms in update and remove

### DIFF
--- a/lib/mongo/collection.extension.js
+++ b/lib/mongo/collection.extension.js
@@ -42,7 +42,7 @@ export default () => {
             config = getMutationConfig(this._name, config);
 
             const resolveResult = (err, result) => {
-              const doc = this.findOne(result);
+              const doc = this.findOne(result, { transform: null });
 
               // OPTIMISTIC UI CODE
               compensateForLatency(config._channels, Events.INSERT, doc);
@@ -82,7 +82,7 @@ export default () => {
             config = getMutationConfig(this._name, config);
 
             // TODO: optimization check if it has _id or _id with {$in} so we don't have to redo this.
-            const findOptions = { fields: { _id: 1 } };
+            const findOptions = { fields: { _id: 1 }, transform: null };
             if (!config.multi) findOptions.limit = 1;
             let docIds = this.find(selector, findOptions).fetch().map(doc => doc._id);
 
@@ -92,7 +92,8 @@ export default () => {
               let docs = this.find({
                   _id: {$in: docIds}
               }, {
-                  fields: fieldsOptions
+                  fields: fieldsOptions,
+                  transform: null
               }).fetch();
 
               const client = getRedisClient();
@@ -139,7 +140,8 @@ export default () => {
 
             // TODO: optimization check if it has _id or _id with {$in} so we don't have to redo this.
             let docIds = this.find(selector, {
-                fields: {_id: 1}
+                fields: {_id: 1},
+                transform: null
             }).fetch().map(doc => doc._id);
 
             const resolveResult = (err, result) => {


### PR DESCRIPTION
Documents should not be transformed (performance), if global transforming was activated for a collection.
