### PR TITLE
Fix fields and ddp connection checks

### DIFF
--- a/lib/cache/ObservableCollection.js
+++ b/lib/cache/ObservableCollection.js
@@ -237,7 +237,7 @@ export default class ObservableCollection {
     _changeNormal(storedDoc, modifiedFields) {
         let fields = {};
 
-        if (this.options.fields) {
+        if (this.fieldsArray) {
             if (this.isFieldsProjectionByExclusion) {
                 fields = filterDisallowedFields(this.fieldsArray, modifiedFields)
             } else {
@@ -262,7 +262,7 @@ export default class ObservableCollection {
         // make sure this also works with arrays
         processUndefined(result, fields);
 
-        if (this.options.fields) {
+        if (this.fieldsArray) {
             this.projectFieldsOnDoc(result);
         }
 

--- a/lib/cache/PublicationEntry.js
+++ b/lib/cache/PublicationEntry.js
@@ -97,7 +97,7 @@ export default class PublicationEntry {
         const invoke = DDP._CurrentInvocation.get();
         // Note this won't be as performant with publishComposite, unless you use cultofcoders:publish-composite which passes connection along
 
-        if (invoke) {
+        if (invoke && invoke.connection) {
             // we send first to all watchers for invoke.connection.id
             // defer the rest so that the method yields quickly to the user, because we have applied it's changes.
             const currentId = invoke.connection.id;


### PR DESCRIPTION
We’re finally about to use redis-oplog in production @ TeamGrid 🎉🎉🎉
I’ve found some issues while testing it with our app.

**check fieldsArray instead of options.fields**
I had strange issues while checking options.fields. It looked like
options.fields got changed after the cursor was initialized.
options.fields was an empty object but the fieldsArray was undefined.
Since there is only a check if options.fields is defined, the result
was an exception, that fieldsArray is undefined.

**check if current invocation has a connection**
I have some cases where the connection is null. I think it has
something todo with server side method calls
(https://github.com/meteor/meteor/blob/84ed04b8f3b99cf16b5540f2e0193d47e
4f8ccf6/packages/ddp-server/livedata_server.js#L1631-L1647)