### PR TITLE
segregate mutation from config retrieval - fixes #225

### DIFF
--- a/lib/mongo/Mutator.js
+++ b/lib/mongo/Mutator.js
@@ -20,10 +20,7 @@ export default class Mutator {
     }
 
     static insert(Originals, data, _config) {
-        const config = getMutationConfig(this, _config, {
-            doc: data,
-            event: Events.INSERT
-        });
+        const config = getMutationConfig(this, _config);
 
         if (!config.pushToRedis) {
             return Originals.insert.call(this, data);
@@ -31,6 +28,13 @@ export default class Mutator {
 
         try {
             const docId = Originals.insert.call(this, data);
+
+            const mutationObject = {
+                doc: {_id: docId, ...data},
+                event: Events.INSERT,
+            }
+
+            Mutator._handleMutation.call(this, config, mutationObject);
 
             if (_.isFunction(_config)) {
                 _config.call(this, null, docId);
@@ -57,11 +61,14 @@ export default class Mutator {
      * @returns {*}
      */
     static update(Originals, selector, modifier, _config, callback) {
-        const config = getMutationConfig(this, _config, {
+        const config = getMutationConfig(this, _config);
+        const mutationObject = {
             event: Events.UPDATE,
             selector,
             modifier
-        });
+        };
+
+        Mutator._handleMutation.call(this, config, mutationObject);
 
         if (!config.pushToRedis) {
             return Originals.update.call(this, selector, modifier, _config);
@@ -108,6 +115,19 @@ export default class Mutator {
                 return callback.call(this, e);
             } else {
                 throw e;
+            }
+        }
+    }
+
+    /**
+     * @param  config
+     * @param  mutationObject
+     */
+    static _handleMutation(config, mutationObject) {
+        if(this._redisOplog) {
+            const {mutation} = this._redisOplog;
+            if (mutation) {
+                mutation.apply(this, arguments);
             }
         }
     }
@@ -167,10 +187,13 @@ export default class Mutator {
      * @returns {*}
      */
     static remove(Originals, selector, _config) {
-        const config = getMutationConfig(this, _config, {
+        const config = getMutationConfig(this, _config);
+        const mutationObject = {
             selector,
             event: Events.REMOVE,
-        });
+        };
+
+        Mutator._handleMutation.call(this, config, mutationObject);
 
         if (!config.pushToRedis) {
             return Originals.remove.call(this, selector);

--- a/lib/mongo/lib/getMutationConfig.js
+++ b/lib/mongo/lib/getMutationConfig.js
@@ -15,13 +15,6 @@ export default function (collection, _config, mutationObject) {
 
     let config = _.extend({}, Config.mutationDefaults, _config);
 
-    if (collection._redisOplog) {
-        const {mutation} = collection._redisOplog;
-        if (mutation) {
-            mutation.call(collection, config, mutationObject)
-        }
-    }
-
     config._channels = getChannels(collectionName, config);
 
     return config;


### PR DESCRIPTION
Client side mutations generate their _id client side to allow optimistic updates. On the server however the _id is not generated until the document is inserted.