### PR TITLE
Error message when missing redisOplog settings.

### DIFF
--- a/redis-oplog.js
+++ b/redis-oplog.js
@@ -36,4 +36,6 @@ export {
 
 if (Meteor.settings.redisOplog) {
     init(Meteor.settings.redisOplog);
+} else {
+    console.log("RedisOplog could not find Meteor.settings.redisOplog. Did you add the redisOplog settings at Meteor.settings.redisOplog?");
 }


### PR DESCRIPTION
I ran into this problem upon setting up `redisOplog`... I had added my settings accidentally at `Meteor.settings.public.redisOplog` and it couldn't find them. And I didn't get any error messages about 1. not finding the settings and 2. if it tried to use the default settings, I didn't receive any errors about connections and not finding `redis`.

I think you should add something like this to help new users.  If not, there's no way to know what's going on.