### PR TITLE
More defensive handling of DDP._CurrentPublicationInvocation

### DIFF
--- a/lib/mongo/extendObserveChanges.js
+++ b/lib/mongo/extendObserveChanges.js
@@ -111,7 +111,7 @@ function getObserverConnection(observer) {
         return observer.connection;
     }
 
-    const currentPublishInvoke = DDP._CurrentPublicationInvocation.get();
+    const currentPublishInvoke = DDP._CurrentPublicationInvocation && DDP._CurrentPublicationInvocation.get();
 
     if (currentPublishInvoke) {
         return currentPublishInvoke.connection;


### PR DESCRIPTION
In my app, I'm seeing this error on startup:

```
TypeError: Cannot read property 'get' of undefined
    at getObserverConnection (packages/cultofcoders:redis-oplog/lib/mongo/extendObserveChanges.js:114:34)
    at createObserve (packages/cultofcoders:redis-oplog/lib/mongo/extendObserveChanges.js:57:21)
    at [object Object].Object.assign.observe (packages/cultofcoders:redis-oplog/lib/mongo/extendObserveChanges.js:25:51)
    at <...stack trace in my app...>
```

To fix this, I've added more defensive handling for the case where `DDP._CurrentPublicationInvocation` is undefined.