### PR TITLE
Use redis prefix for channels

### DIFF
--- a/lib/cache/lib/getChannels.js
+++ b/lib/cache/lib/getChannels.js
@@ -1,5 +1,5 @@
 import { _ } from 'meteor/underscore';
-import Config from '../../config';
+import getChannelName from '../../utils/getChannelName';
 
 export default (collectionName, {namespace, channel, namespaces, channels}) => {
     let channelStrings = [];
@@ -28,5 +28,5 @@ export default (collectionName, {namespace, channel, namespaces, channels}) => {
         channelStrings.push(collectionName);
     }
 
-    return channelStrings.map(c => (Config.redis.prefix || '') + c);
+    return channelStrings.map(getChannelName);
 }

--- a/lib/cache/lib/getChannels.js
+++ b/lib/cache/lib/getChannels.js
@@ -1,4 +1,5 @@
 import { _ } from 'meteor/underscore';
+import Config from '../../config';
 
 export default (collectionName, {namespace, channel, namespaces, channels}) => {
     let channelStrings = [];
@@ -27,5 +28,5 @@ export default (collectionName, {namespace, channel, namespaces, channels}) => {
         channelStrings.push(collectionName);
     }
 
-    return channelStrings;
+    return channelStrings.map(c => (Config.redis.prefix || '') + c);
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,9 +12,9 @@ let Config = {
     passConfigDown: false,
     redis: {
         port: 6379,
-        host: '127.0.0.1',
-        prefix: ''
+        host: '127.0.0.1'
     },
+    globalRedisPrefix: '',
     retryIntervalMs: 10000,
     redisExtras: {
         retry_strategy: function (options) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,6 +13,7 @@ let Config = {
     redis: {
         port: 6379,
         host: '127.0.0.1',
+        prefix: ''
     },
     retryIntervalMs: 10000,
     redisExtras: {

--- a/lib/mongo/lib/compensateForLatency.js
+++ b/lib/mongo/lib/compensateForLatency.js
@@ -1,5 +1,7 @@
 import RedisSubscriptionManager from '../../redis/RedisSubscriptionManager';
 import { Events, RedisPipe } from '../../constants';
+import Config from '../../config';
+
 /**
  * Latency compensator acts exactly as a synthetic event, which is very quick
  *
@@ -17,7 +19,7 @@ export default (channels, collectionName, event, doc, fields) => {
             [RedisPipe.FIELDS]: fields
         });
 
-        const dedicatedChannel = collectionName + '::' + doc._id;
+        const dedicatedChannel = (Config.redis.prefix || '') + collectionName + '::' + doc._id;
         RedisSubscriptionManager.process(dedicatedChannel, {
             [RedisPipe.DOC]: doc,
             [RedisPipe.EVENT]: event,

--- a/lib/mongo/lib/compensateForLatency.js
+++ b/lib/mongo/lib/compensateForLatency.js
@@ -1,6 +1,6 @@
 import RedisSubscriptionManager from '../../redis/RedisSubscriptionManager';
 import { Events, RedisPipe } from '../../constants';
-import Config from '../../config';
+import getChannelName from '../../utils/getChannelName';
 
 /**
  * Latency compensator acts exactly as a synthetic event, which is very quick
@@ -19,7 +19,7 @@ export default (channels, collectionName, event, doc, fields) => {
             [RedisPipe.FIELDS]: fields
         });
 
-        const dedicatedChannel = (Config.redis.prefix || '') + collectionName + '::' + doc._id;
+        const dedicatedChannel = getChannelName(collectionName + '::' + doc._id);
         RedisSubscriptionManager.process(dedicatedChannel, {
             [RedisPipe.DOC]: doc,
             [RedisPipe.EVENT]: event,

--- a/lib/mongo/lib/publish.js
+++ b/lib/mongo/lib/publish.js
@@ -1,5 +1,6 @@
 import { EJSON } from 'meteor/ejson';
 import { getRedisPusher } from '../../redis/getRedisClient';
+import Config from '../../config';
 
 /**
  * @param collectionName {string}
@@ -19,7 +20,7 @@ export default (collectionName, channels, data, namespacedId) => {
             }
 
             if (namespacedId) {
-                client.publish(collectionName + '::' + namespacedId, message);
+                client.publish((Config.redis.prefix || '') + collectionName + '::' + namespacedId, message);
             }
         })
     }

--- a/lib/mongo/lib/publish.js
+++ b/lib/mongo/lib/publish.js
@@ -1,6 +1,6 @@
 import { EJSON } from 'meteor/ejson';
 import { getRedisPusher } from '../../redis/getRedisClient';
-import Config from '../../config';
+import getChannelName from '../../utils/getChannelName';
 
 /**
  * @param collectionName {string}
@@ -20,7 +20,7 @@ export default (collectionName, channels, data, namespacedId) => {
             }
 
             if (namespacedId) {
-                client.publish((Config.redis.prefix || '') + collectionName + '::' + namespacedId, message);
+                client.publish(getChannelName(collectionName + '::' + namespacedId), message);
             }
         })
     }

--- a/lib/redis/RedisSubscriber.js
+++ b/lib/redis/RedisSubscriber.js
@@ -5,6 +5,7 @@ import { Meteor } from 'meteor/meteor';
 import extractIdsFromSelector from '../utils/extractIdsFromSelector';
 import RedisSubscriptionManager from './RedisSubscriptionManager';
 import syntheticProcessor from '../processors/synthetic';
+import Config from '../config';
 
 export default class RedisSubscriber {
     /**
@@ -37,7 +38,7 @@ export default class RedisSubscriber {
             case Strategy.DEDICATED_CHANNELS:
                 const ids = extractIdsFromSelector(this.observableCollection.selector);
 
-                return ids.map(id => collectionName + '::' + id);
+                return ids.map(id => (Config.redis.prefix || '') + collectionName + '::' + id);
             default:
                 throw new Meteor.Error(`Strategy could not be found: ${this.strategy}`)
         }

--- a/lib/redis/RedisSubscriber.js
+++ b/lib/redis/RedisSubscriber.js
@@ -5,7 +5,7 @@ import { Meteor } from 'meteor/meteor';
 import extractIdsFromSelector from '../utils/extractIdsFromSelector';
 import RedisSubscriptionManager from './RedisSubscriptionManager';
 import syntheticProcessor from '../processors/synthetic';
-import Config from '../config';
+import getChannelName from '../utils/getChannelName';
 
 export default class RedisSubscriber {
     /**
@@ -20,6 +20,7 @@ export default class RedisSubscriber {
 
         // We do this because we override the behavior of dedicated "_id" channels
         this.channels = this.getChannels(this.observableCollection.channels);
+        console.log("GOT CHANNELS", this.channels);
 
         RedisSubscriptionManager.attach(this);
     }
@@ -38,7 +39,7 @@ export default class RedisSubscriber {
             case Strategy.DEDICATED_CHANNELS:
                 const ids = extractIdsFromSelector(this.observableCollection.selector);
 
-                return ids.map(id => (Config.redis.prefix || '') + collectionName + '::' + id);
+                return ids.map(id => getChannelName(collectionName + '::' + id));
             default:
                 throw new Meteor.Error(`Strategy could not be found: ${this.strategy}`)
         }

--- a/lib/utils/getChannelName.js
+++ b/lib/utils/getChannelName.js
@@ -1,0 +1,11 @@
+import Config from '../config';
+
+/**
+ * Given a base channel name, applies the global prefix.
+ *
+ * @param baseChannelName
+ * @return {string}
+ */
+export default function getChannelName(baseChannelName) {
+    return (Config.globalRedisPrefix || '') + baseChannelName;
+}


### PR DESCRIPTION
node-redis does not apply the prefix to channel names (they're [only applied to keys](https://github.com/NodeRedis/node_redis/blob/79558c524ff783000a6027fb159739770f98b10e/index.js#L934), and [getKeyIndexes](https://github.com/NodeRedis/redis-commands/blob/master/index.js#L66) doesn't treat [channel names as keys](https://github.com/NodeRedis/redis-commands/blob/master/commands.json#L1017)).

This patch applies the Redis prefix to the channel names used by redis-oplog.