### PR TITLE
Add externalRedisPublisher option

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -15,6 +15,7 @@ let Config = {
         host: '127.0.0.1',
     },
     retryIntervalMs: 10000,
+    externalRedisPublisher: false,
     redisExtras: {
         retry_strategy: function (options) {
             return Config.retryIntervalMs;

--- a/lib/mongo/lib/dispatchers.js
+++ b/lib/mongo/lib/dispatchers.js
@@ -24,22 +24,24 @@ const dispatchUpdate = function(
         });
     }
 
-    if (!Config.externalRedisPublisher) {
-        Meteor.defer(() => {
-            docIds.forEach(docId => {
-                publish(
-                    collectionName,
-                    channels,
-                    {
-                        [RedisPipe.EVENT]: Events.UPDATE,
-                        [RedisPipe.FIELDS]: fields,
-                        [RedisPipe.DOC]: { _id: docId }
-                    },
-                    docId
-                );
-            });
-        });
+    if (Config.externalRedisPublisher) {
+        return;
     }
+
+    Meteor.defer(() => {
+        docIds.forEach(docId => {
+            publish(
+                collectionName,
+                channels,
+                {
+                    [RedisPipe.EVENT]: Events.UPDATE,
+                    [RedisPipe.FIELDS]: fields,
+                    [RedisPipe.DOC]: { _id: docId }
+                },
+                docId
+            );
+        });
+    });
 };
 
 const dispatchRemove = function(optimistic, collectionName, channels, docIds) {
@@ -51,21 +53,23 @@ const dispatchRemove = function(optimistic, collectionName, channels, docIds) {
         });
     }
 
-    if (!Config.externalRedisPublisher) {
-        Meteor.defer(() => {
-            docIds.forEach(docId => {
-                publish(
-                    collectionName,
-                    channels,
-                    {
-                        [RedisPipe.EVENT]: Events.REMOVE,
-                        [RedisPipe.DOC]: { _id: docId }
-                    },
-                    docId
-                );
-            });
-        });
+    if (Config.externalRedisPublisher) {
+        return;
     }
+
+    Meteor.defer(() => {
+        docIds.forEach(docId => {
+            publish(
+                collectionName,
+                channels,
+                {
+                    [RedisPipe.EVENT]: Events.REMOVE,
+                    [RedisPipe.DOC]: { _id: docId }
+                },
+                docId
+            );
+        });
+    });
 };
 
 const dispatchInsert = function(optimistic, collectionName, channels, docId) {
@@ -76,14 +80,16 @@ const dispatchInsert = function(optimistic, collectionName, channels, docId) {
         });
     }
 
-    if (!Config.externalRedisPublisher) {
-        Meteor.defer(() => {
-            publish(this._name, channels, {
-                [RedisPipe.EVENT]: Events.INSERT,
-                [RedisPipe.DOC]: { _id: docId }
-            });
-        });
+    if (Config.externalRedisPublisher) {
+        return;
     }
+
+    Meteor.defer(() => {
+        publish(this._name, channels, {
+            [RedisPipe.EVENT]: Events.INSERT,
+            [RedisPipe.DOC]: { _id: docId }
+        });
+    });
 };
 
 export { dispatchInsert, dispatchUpdate, dispatchRemove };

--- a/lib/mongo/lib/dispatchers.js
+++ b/lib/mongo/lib/dispatchers.js
@@ -3,6 +3,7 @@ import { Events, RedisPipe } from '../../constants';
 import publish from './publish';
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
+import Config from '../../config';
 
 const dispatchUpdate = function(
     optimistic,
@@ -23,20 +24,22 @@ const dispatchUpdate = function(
         });
     }
 
-    Meteor.defer(() => {
-        docIds.forEach(docId => {
-            publish(
-                collectionName,
-                channels,
-                {
-                    [RedisPipe.EVENT]: Events.UPDATE,
-                    [RedisPipe.FIELDS]: fields,
-                    [RedisPipe.DOC]: { _id: docId }
-                },
-                docId
-            );
+    if (!Config.externalRedisPublisher) {
+        Meteor.defer(() => {
+            docIds.forEach(docId => {
+                publish(
+                    collectionName,
+                    channels,
+                    {
+                        [RedisPipe.EVENT]: Events.UPDATE,
+                        [RedisPipe.FIELDS]: fields,
+                        [RedisPipe.DOC]: { _id: docId }
+                    },
+                    docId
+                );
+            });
         });
-    });
+    }
 };
 
 const dispatchRemove = function(optimistic, collectionName, channels, docIds) {
@@ -48,19 +51,21 @@ const dispatchRemove = function(optimistic, collectionName, channels, docIds) {
         });
     }
 
-    Meteor.defer(() => {
-        docIds.forEach(docId => {
-            publish(
-                collectionName,
-                channels,
-                {
-                    [RedisPipe.EVENT]: Events.REMOVE,
-                    [RedisPipe.DOC]: { _id: docId }
-                },
-                docId
-            );
+    if (!Config.externalRedisPublisher) {
+        Meteor.defer(() => {
+            docIds.forEach(docId => {
+                publish(
+                    collectionName,
+                    channels,
+                    {
+                        [RedisPipe.EVENT]: Events.REMOVE,
+                        [RedisPipe.DOC]: { _id: docId }
+                    },
+                    docId
+                );
+            });
         });
-    });
+    }
 };
 
 const dispatchInsert = function(optimistic, collectionName, channels, docId) {
@@ -71,12 +76,14 @@ const dispatchInsert = function(optimistic, collectionName, channels, docId) {
         });
     }
 
-    Meteor.defer(() => {
-        publish(this._name, channels, {
-            [RedisPipe.EVENT]: Events.INSERT,
-            [RedisPipe.DOC]: { _id: docId }
+    if (!Config.externalRedisPublisher) {
+        Meteor.defer(() => {
+            publish(this._name, channels, {
+                [RedisPipe.EVENT]: Events.INSERT,
+                [RedisPipe.DOC]: { _id: docId }
+            });
         });
-    });
+    }
 };
 
 export { dispatchInsert, dispatchUpdate, dispatchRemove };


### PR DESCRIPTION
Add a new option, `externalRedisPublisher`, that can be used if there is an external system that's responsible for writing changes to Redis. It works like `pushToRedis: false`, except that it still handles optimistic UI.