### PR TITLE
Add insert handler for direct processor

### DIFF
--- a/lib/processors/direct.js
+++ b/lib/processors/direct.js
@@ -14,10 +14,23 @@ export default function (observableCollection, event, doc, modifiedFields) {
         case Events.REMOVE:
             handleRemove(observableCollection, doc);
             break;
+        case Events.INSERT:
+            handleInsert(observableCollection, doc);
+            break;
         default:
             throw new Meteor.Error(`Invalid event specified: ${event}`)
     }
 }
+
+/**
+ * @param observableCollection
+ * @param doc
+ */
+const handleInsert = function (observableCollection, doc) {
+    if (!observableCollection.contains(doc._id) && observableCollection.isEligible(doc)) {
+        observableCollection.add(doc);
+    }
+};
 
 /**
  * @param observableCollection


### PR DESCRIPTION
It's valid to publish a record by ID before that record exists. Here's a (very contrived) example that works with vanilla Meteor, but causes and error and incorrect behavior with redis-oplog:

```
Foo = new Mongo.Collection('Foo')
Meteor.publish('newfoo', function() {
  newid = Random.id();

  Meteor.setTimeout(() => {
    Foo.insert({ _id: newid })
  }, 500)

  return Foo.find({ _id: newid });
})
```

I'm hitting this in my app because I'm using a publishComposite-style technique to publish a parent record that has a list of child IDs, as well as those child records. This works if I insert the child before updating the parent, but it's a lot easier for me to to it the other way around (update the parent, then insert the child) because I have some collection hooks that synchronize the child record to an external system and that synchronization code needs to be able to determine the parent record from the child record.

Somewhat-obtuse use-case aside, this PR adds a simple insert handler to the direct processor to handle this edge case correctly.