### PR TITLE
Avoid double-dispatch of changes as much as possible when using external publisher

### DIFF
--- a/lib/cache/PublicationEntry.js
+++ b/lib/cache/PublicationEntry.js
@@ -5,6 +5,7 @@ import debug from '../debug';
 import { getStrategy } from '../processors';
 import { DDP } from 'meteor/ddp-client';
 import { _ } from 'meteor/underscore';
+import Config from '../config';
 
 export default class PublicationEntry {
     constructor(id, cursor, factory) {
@@ -139,6 +140,20 @@ export default class PublicationEntry {
                 currentObservers.forEach(observer => {
                     observer[action].call(observer, ...args);
                 });
+            }
+
+            if (Config.externalRedisPublisher) {
+                // When we're using an external publisher rather than sending
+                // event to Redis ourselves, we won't be able to ignore Redis
+                // events corresponding to writes we've already processed as
+                // part of the optimistic-ui system.
+                //
+                // This duplication is unavoidable for things that actually
+                // need to be processed for optimistic-ui, but we can limit
+                // it to just the "currentObservers" above rather than all
+                // observers -- we'll process the changes for other observers
+                // when we see the write notifications coming in from Redis.
+                return;
             }
 
             // defer the rest so that the method yields quickly to the user, because we have applied it's changes.

--- a/lib/mongo/lib/dispatchers.js
+++ b/lib/mongo/lib/dispatchers.js
@@ -17,7 +17,7 @@ const getWriteFence = function (optimistic) {
 const dispatchEvents = function (fence, collectionName, channels, events) {
     if (fence) {
         const write = fence.beginWrite();
-        RedisSubscriptionManager.queue.queueTask(() => {
+        RedisSubscriptionManager.queue.queueTask(Meteor.bindEnvironment(() => {
             try {
               events.forEach((event) => {
                 channels.forEach(channelName => {
@@ -25,12 +25,14 @@ const dispatchEvents = function (fence, collectionName, channels, events) {
                 });
                 const docId = event[RedisPipe.DOC]._id;
                 const dedicatedChannel = getChannelName(`${collectionName}::${docId}`);
+                console.log("OPTIMISTIC PROCESS", dedicatedChannel)
                 RedisSubscriptionManager.process(dedicatedChannel, event);
+                console.log("DONE")
               });
             } finally {
               write.committed();
             }
-        });
+        }));
     }
 
     if (Config.externalRedisPublisher) {

--- a/lib/mongo/lib/dispatchers.js
+++ b/lib/mongo/lib/dispatchers.js
@@ -25,9 +25,7 @@ const dispatchEvents = function (fence, collectionName, channels, events) {
                 });
                 const docId = event[RedisPipe.DOC]._id;
                 const dedicatedChannel = getChannelName(`${collectionName}::${docId}`);
-                console.log("OPTIMISTIC PROCESS", dedicatedChannel)
                 RedisSubscriptionManager.process(dedicatedChannel, event);
-                console.log("DONE")
               });
             } finally {
               write.committed();

--- a/lib/redis/RedisSubscriber.js
+++ b/lib/redis/RedisSubscriber.js
@@ -20,7 +20,6 @@ export default class RedisSubscriber {
 
         // We do this because we override the behavior of dedicated "_id" channels
         this.channels = this.getChannels(this.observableCollection.channels);
-        console.log("GOT CHANNELS", this.channels);
 
         RedisSubscriptionManager.attach(this);
     }


### PR DESCRIPTION
This PR does two things:

- Add a bindEnvironment when dispatching events in `dispatcher.js` so that `DDP._CurrentInvocation.get();` in PublicationEntry.js works -- I think we were always hitting the second branch and running all observers synchronously.

- When using an external redis publisher, don't process local observers other than those that are strictly required for optimistic UI. External publishers won't be able to take advantage of the optimization from https://github.com/cult-of-coders/redis-oplog/pull/260 -- they'll always re-process events from Redis -- so we can at least make the initial optimistic pass as minimal as possible (every else will get updated when the write notification comes in from Redis)