### PR TITLE
Maximize use of original methods when using an external publisher

### DIFF
--- a/lib/mongo/Mutator.js
+++ b/lib/mongo/Mutator.js
@@ -35,7 +35,7 @@ export default class Mutator {
             event: Events.INSERT,
         });
 
-        if (!config.pushToRedis) {
+        if (canUseOriginalMethod(config)) {
             return Originals.insert.call(this, data);
         }
 
@@ -93,7 +93,7 @@ export default class Mutator {
             modifier,
         });
 
-        if (!config.pushToRedis) {
+        if (canUseOriginalMethod(config)) {
             return Originals.update.call(this, selector, modifier, config);
         }
 
@@ -262,7 +262,7 @@ export default class Mutator {
             event: Events.REMOVE,
         });
 
-        if (!config.pushToRedis) {
+        if (canUseOriginalMethod(config)) {
             return Originals.remove.call(this, selector);
         }
 
@@ -309,4 +309,18 @@ export default class Mutator {
             }
         }
     }
+}
+
+function canUseOriginalMethod(mutationConfig) {
+    // There are two cases where we can use the original mutators rather than
+    // our overriden ones:
+    //
+    // 1) The user set pushToRedis: false, indicating they don't need realtime
+    //    updates at all.
+    //
+    // 2) The user is using an external redis publisher, so we don't need to
+    //    figure out what to publish to redis, and this update doesn't need
+    //    optimistic-ui processing, so we don't need to synchronously run
+    //    observers.
+    return !mutationConfig.pushToRedis || (Config.externalRedisPublisher && !mutationConfig.optimistic);
 }

--- a/lib/mongo/lib/getMutationConfig.js
+++ b/lib/mongo/lib/getMutationConfig.js
@@ -13,7 +13,18 @@ export default function (collection, _config, mutationObject) {
         _config = {};
     }
 
-    let config = _.extend({}, Config.mutationDefaults, _config);
+    const defaultOverrides = {};
+    if (!DDP._CurrentMethodInvocation.get()) {
+        // If we're not in a method, then we should never need to do optimistic
+        // ui processing.
+        //
+        // However, we allow users to really force it by explicitly passing
+        // optimistic: true if they want to use the local-dispatch code path
+        // rather than going through Redis.
+        defaultOverrides.optimistic = false;
+    }
+
+    let config = _.extend({}, Config.mutationDefaults, defaultOverrides, _config);
 
     if (collection._redisOplog) {
         const {mutation} = collection._redisOplog;


### PR DESCRIPTION
This PR makes two changes to allow us to more frequently use the original insert/update/delete methods when a user is using an external publisher:

1) Use the original methods any time we're using an external redis publisher AND we don't need optimistic UI processing

2) Default to disabling optimistic UI processing if we're not inside a method.

This means that when using an external publisher (so we don't need to do any work to figure out what changes to publish to Redis), we can always use the original methods for things that aren't part of a Meteor method, and users can easily have us always use the original methods by disabling optimistic UI processing.