### PR TITLE
update dedicated channel name for Mongo.ObjectID's

### DIFF
--- a/lib/mongo/lib/dispatchers.js
+++ b/lib/mongo/lib/dispatchers.js
@@ -4,7 +4,7 @@ import { EJSON } from 'meteor/ejson';
 import { Events, RedisPipe } from '../../constants';
 import RedisSubscriptionManager from '../../redis/RedisSubscriptionManager';
 import { getRedisPusher } from "../../redis/getRedisClient";
-import getChannelName from '../../utils/getChannelName';
+import getDedicatedChannel from '../../utils/getDedicatedChannel';
 import Config from '../../config';
 
 const getWriteFence = function (optimistic) {
@@ -24,7 +24,7 @@ const dispatchEvents = function (fence, collectionName, channels, events) {
                   RedisSubscriptionManager.process(channelName, event);
                 });
                 const docId = event[RedisPipe.DOC]._id;
-                const dedicatedChannel = getChannelName(`${collectionName}::${docId}`);
+                const dedicatedChannel = getDedicatedChannel(collectionName, docId);
                 RedisSubscriptionManager.process(dedicatedChannel, event);
               });
             } finally {
@@ -45,7 +45,7 @@ const dispatchEvents = function (fence, collectionName, channels, events) {
                 client.publish(channelName, message);
             });
             const docId = event[RedisPipe.DOC]._id;
-            const dedicatedChannel = getChannelName(`${collectionName}::${docId}`);
+            const dedicatedChannel = getDedicatedChannel(collectionName, docId);
             client.publish(dedicatedChannel, message);
         });
     });

--- a/lib/redis/RedisSubscriber.js
+++ b/lib/redis/RedisSubscriber.js
@@ -5,7 +5,7 @@ import { Meteor } from 'meteor/meteor';
 import extractIdsFromSelector from '../utils/extractIdsFromSelector';
 import RedisSubscriptionManager from './RedisSubscriptionManager';
 import syntheticProcessor from '../processors/synthetic';
-import getChannelName from '../utils/getChannelName';
+import getDedicatedChannel from '../utils/getDedicatedChannel';
 
 export default class RedisSubscriber {
     /**
@@ -38,7 +38,7 @@ export default class RedisSubscriber {
             case Strategy.DEDICATED_CHANNELS:
                 const ids = extractIdsFromSelector(this.observableCollection.selector);
 
-                return ids.map(id => getChannelName(collectionName + '::' + id));
+                return ids.map(id => getDedicatedChannel(collectionName, id));
             default:
                 throw new Meteor.Error(`Strategy could not be found: ${this.strategy}`)
         }

--- a/lib/utils/getDedicatedChannel.js
+++ b/lib/utils/getDedicatedChannel.js
@@ -1,0 +1,7 @@
+import { MongoID } from 'meteor/mongo-id';
+import getChannelName from './getChannelName';
+
+export default function getDedicatedChannel(collectionName, docId){
+  const channelName = `${collectionName}::${MongoID.idStringify(docId)}`;
+  return getChannelName(channelName);
+}


### PR DESCRIPTION
Not really a bug, but just cleans up the naming of dedicated channels.

Old version: `collection::ObjectId(xyz)`
New version: `collection::xyz`