### PR TITLE
Roll back invalid optimization for externalRedisPublisher

### DIFF
--- a/lib/cache/PublicationEntry.js
+++ b/lib/cache/PublicationEntry.js
@@ -142,20 +142,6 @@ export default class PublicationEntry {
                 });
             }
 
-            if (Config.externalRedisPublisher) {
-                // When we're using an external publisher rather than sending
-                // event to Redis ourselves, we won't be able to ignore Redis
-                // events corresponding to writes we've already processed as
-                // part of the optimistic-ui system.
-                //
-                // This duplication is unavoidable for things that actually
-                // need to be processed for optimistic-ui, but we can limit
-                // it to just the "currentObservers" above rather than all
-                // observers -- we'll process the changes for other observers
-                // when we see the write notifications coming in from Redis.
-                return;
-            }
-
             // defer the rest so that the method yields quickly to the user, because we have applied it's changes.
             Meteor.defer(() => {
                 this.observers.forEach(observer => {


### PR DESCRIPTION
I had added an optimization that caused redis-oplog to only send the updates that were necessary for optimistic UI when using `externalRedisPublisher`, because we'll have to re-process the changes anyway when we get the notification from Redis (because when we're using an external redis publisher, we can't track which updates we have and haven't dealt with).

Unfortunately, this optimization was incorrect -- because we only send updates if our cache indicates a change actually occurred, this optimization caused us to not send updates to other clients on the server that accepted the change.

What would happen is:

1) The server would accept the change and write to Mongo
2) It would send out the updates needed for optimistic UI changes, and skip sending other updates
3) It would receive a message from Redis about the change
4) Because it had already seen the change and updated its cache, it wouldn't send out an update to other clients that hadn't received the optimistic UI updates

This PR reverts the optimization.