### PR TITLE
Remove usage of meteor/id-map

### DIFF
--- a/lib/cache/mongoIdMap.js
+++ b/lib/cache/mongoIdMap.js
@@ -1,40 +1,87 @@
-import { IdMap } from 'meteor/id-map';
 import { MongoID } from 'meteor/mongo-id';
 
-export class MongoIDMap extends IdMap {
-    constructor() {
-        super(
-            MongoID.idStringify,
-            MongoID.idParse,
-        );
+export class MongoIDMap {
+
+    constructor(idStringify, idParse) {
+        this._internal = new Map();
+        this._idStringify = idStringify || MongoID.idStringify;
+        this._idParse = idParse || MongoID.idParse;
+    }
+
+    get(id) {
+        const key = this._idStringify(id);
+        return this._internal.get(key);
     }
 
     pop(id) {
         const key = this._idStringify(id);
-        const ret = this._map[key];
-        delete this._map[key];
+        const ret = this._internal.get(key);
+        this._internal.delete(key);
         return ret;
     }
 
+    set(id, value) {
+        const key = this._idStringify(id);
+        this._internal.set(key, value);
+    }
+
+    setDefault(id, def) {
+        const key = this._idStringify(id);
+        if (this._internal.has(key)) {
+            return this._internal.get(key);
+        }
+        this._internal.set(key, def);
+        return def;
+    }
+
+    remove(id) {
+        const key = this._idStringify(id);
+        this._internal.delete(key);
+    }
+
+    has(id) {
+        const key = this._idStringify(id);
+        return this._internal.has(key);
+    }
+
+    size() {
+        return this._internal.size;
+    }
+
+    empty() {
+        return this._internal.size === 0;
+    }
+
+    clear() {
+        this._internal.clear();
+    }
+
     keys() {
-        return _.keys(this._map).map(id => this._idParse(id));
+        return Array.from(this._internal.keys()).map(key => this._idParse(key))
+    }
+
+    forEach(iterator) {
+        this._internal.forEach((value, key) => {
+            iterator.call(null, value, this._idParse(key));
+        });
     }
 
     compareWith(other, callbacks) {
-        // shallow clone to protect from mutations during iteration
-        const left = Object.assign({}, this._map);
-        const right = Object.assign({}, other._map);
+        // operate on the _internal maps to avoid overhead of parsing id's.
+        const leftMap = this._internal;
+        const rightMap = other._internal;
 
-        _.each(left, (leftValue, id) => {
-            if (_.has(right, id))
-                callbacks.both && callbacks.both(this._idParse(id), leftValue, right[id]);
+        leftMap.forEach((leftValue, key) => {
+            const rightValue = rightMap.get(key);
+            if (rightValue != null)
+                callbacks.both && callbacks.both(this._idParse(key), leftValue, rightValue);
             else
-                callbacks.leftOnly && callbacks.leftOnly(this._idParse(id), leftValue);
+                callbacks.leftOnly && callbacks.leftOnly(this._idParse(key), leftValue);
         });
         if (callbacks.rightOnly) {
-            _.each(right, (rightValue, id) => {
-                if (!_.has(left, id))
-                    callbacks.rightOnly(this._idParse(id), rightValue);
+            rightMap.forEach((rightValue, key) => {
+                if (!leftMap.has(key))
+                    callbacks.rightOnly(this._idParse(key), rightValue);
             });
         }
 

--- a/lib/processors/testing/limit-sort.test.js
+++ b/lib/processors/testing/limit-sort.test.js
@@ -1,7 +1,8 @@
+import { MongoID } from 'meteor/mongo-id';
+import { _ } from 'meteor/underscore';
 import process from '../limit-sort';
 import {Events} from '../../constants';
 import ObservableCollection from '../../cache/ObservableCollection';
-import { _ } from 'meteor/underscore';
 
 const Collection = new Mongo.Collection('limit_sort_test');
 
@@ -195,13 +196,13 @@ describe('Processor - Limit Sort', function () {
         let docId = ids[8];
 
         assert.isUndefined(oc.store.get(docId));
-        let existingIds = _.keys(oc.store._map);
+        let existingIds = oc.store.keys().map(MongoID.idStringify);
 
         Collection.remove({_id: docId});
         process(oc, Events.REMOVE, {_id: docId});
 
         // grab the stringified keys for comparison
-        let newIds = _.keys(oc.store._map);
+        let newIds = oc.store.keys().map(MongoID.idStringify);
         assert.lengthOf(_.difference(existingIds, newIds), 1);
     })
 });

--- a/package.js
+++ b/package.js
@@ -29,7 +29,6 @@ Package.onUse(function(api) {
     'random',
     'ddp-server',
     'diff-sequence',
-    'id-map',
     'mongo-id',
   ]);
 


### PR DESCRIPTION
Change the implementation of `MongoIDMap`, to remove usage of private
fields (`_map`). This should prevent breakage if the implementation of
`IdMap` were to change.

Additionally, change the internal data structure from an `Object` to a `Map`.

---

@theodorDiaconu Getting this patched now, as I'm hoping to get some breaking changes to `id-map` upstreamed.