### PR TITLE
only remove children from fields projection if their parent is top-level

### DIFF
--- a/lib/redis/lib/getFieldsOfInterestFromAll.js
+++ b/lib/redis/lib/getFieldsOfInterestFromAll.js
@@ -37,9 +37,9 @@ export function removeChildrenOfParents(array) {
     let freshArray = [];
 
     array.forEach((element, idxe) => {
-        // add it to freshArray only if there's no {me} + '.' inside the array
+        // add it to freshArray only if there's no field starting with {me} + '.' inside the array
         const foundParent = array.find((subelement, idxs) => {
-            return idxe !== idxs && element.indexOf(`${subelement}.`) >= 0;
+            return idxe !== idxs && element.indexOf(`${subelement}.`) === 0;
         });
 
         if (!foundParent) {

--- a/lib/redis/testing/getFieldsOfInterestFromAll.js
+++ b/lib/redis/testing/getFieldsOfInterestFromAll.js
@@ -40,4 +40,17 @@ describe('#removeChildrenOfParents ', function() {
         assert.isDefined(newArray.find(el => el === 'master.slave.field'));
         assert.isDefined(newArray.find(el => el === 'slave.field'));
     });
+
+    it('Should work when field has a top level field as a substring', function() {
+        const array = [
+            'master.slave.field',
+            'slave.field',
+            'slave',
+        ];
+        const newArray = removeChildrenOfParents(array);
+
+        assert.lengthOf(newArray, 2);
+        assert.isDefined(newArray.find(el => el === 'master.slave.field'));
+        assert.isDefined(newArray.find(el => el === 'slave'));
+    });
 });


### PR DESCRIPTION


Redis oplog does some work to minimize the fields projection given for a mongo query. If we encounter a situation in which fields of interest has two fields `master.slave.field`, and `slave`, the function `removeChildrenOfParents` is currently omitting `master.slave.field` because it sees that `slave.` is already in the list of returned fields. This was causing observes to be called with documents not containing all necessary fields in the Qualia application.

To fix, we say we have only found a parent field if another field starts with the current field, rather than includes it.