### PR TITLE
add support for addedBefore and movedBefore

### DIFF
--- a/lib/cache/ObservableCollection.js
+++ b/lib/cache/ObservableCollection.js
@@ -167,7 +167,7 @@ export default class ObservableCollection {
      * @param doc {Object}
      * @param safe {Boolean} If this is set to true, it assumes that the object is cleaned
      */
-    add(doc, safe = false) {
+    add(doc, safe = false, beforeId = undefined) {
         doc = cloneDeep(doc);
 
         if (!safe) {
@@ -177,21 +177,31 @@ export default class ObservableCollection {
         }
 
         this.store.set(doc._id, doc);
-        this.send('added', doc._id, doc);
+        this.send('added', doc._id, doc, beforeId);
     }
 
     /**
      * We use this method when we receive updates for a document that is not yet in the observable collection store
      * @param docId
+     * @param beforeId
      */
-    addById(docId) {
+    addById(docId, beforeId) {
         const doc = this.collection.findOne({ _id: docId }, this.options);
 
         this.store.set(docId, doc);
 
         if (doc) {
-            this.send('added', doc._id, doc);
+            this.send('added', doc._id, doc, beforeId);
         }
+    }
+
+    /**
+      * We use this to get notifications when a document is moved in a data set.
+      * @param docId
+      * @param beforeId
+    */
+    movedBefore(docId, beforeId) {
+      this.send('movedBefore', docId, beforeId);
     }
 
     /**

--- a/lib/cache/PublicationEntry.js
+++ b/lib/cache/PublicationEntry.js
@@ -138,7 +138,9 @@ export default class PublicationEntry {
 
             if (currentObservers.length) {
                 currentObservers.forEach(observer => {
+                  if (observer[action]) {
                     observer[action].call(observer, ...args);
+                  }
                 });
             }
 
@@ -149,7 +151,9 @@ export default class PublicationEntry {
                         !observer.connection ||
                         observer.connection.id != currentId
                     ) {
+                      if (observer[action]) {
                         observer[action].call(observer, ...args);
+                      }
                     }
                 });
             });

--- a/lib/mongo/extendObserveChanges.js
+++ b/lib/mongo/extendObserveChanges.js
@@ -55,6 +55,12 @@ function createObserve(observer) {
 
     return {
         connection: getObserverConnection(observer),
+        movedBefore(collectionName, docId, beforeId) {
+          console.log(docId, beforeId);
+          if (observer.movedBefore) {
+            observer.movedBefore(docId, beforeId);
+          }
+        },
         added(collectionName, docId, doc) {
             if (observer.added) {
                 observer.added(cloneDeep(doc));
@@ -85,9 +91,18 @@ function createObserveChanges(observer) {
 
     return {
         connection: getObserverConnection(observer),
-        added(collectionName, docId, doc) {
+        movedBefore(collectionName, docId, beforeId) {
+          if (observer.movedBefore) {
+            observer.movedBefore(docId, beforeId);
+          }
+        },
+        added(collectionName, docId, doc, beforeId) {
+          const clonedDoc = cloneDeep(doc);
             if (observer.added) {
-                observer.added(docId, cloneDeep(doc));
+                observer.added(docId, clonedDoc);
+            }
+            if (observer.addedBefore) {
+              observer.addedBefore(docId, clonedDoc, beforeId);
             }
         },
         changed(collectionName, docId, doc) {

--- a/lib/mongo/extendObserveChanges.js
+++ b/lib/mongo/extendObserveChanges.js
@@ -56,7 +56,6 @@ function createObserve(observer) {
     return {
         connection: getObserverConnection(observer),
         movedBefore(collectionName, docId, beforeId) {
-          console.log(docId, beforeId);
           if (observer.movedBefore) {
             observer.movedBefore(docId, beforeId);
           }

--- a/lib/processors/actions/requery.js
+++ b/lib/processors/actions/requery.js
@@ -15,19 +15,31 @@ export default function (observableCollection, newCommer, event, modifiedFields)
     const newStore = new MongoIDMap();
     const freshIds = observableCollection.collection.find(
         selector, { ...options, fields: { _id: 1 } }).fetch();
-    freshIds.forEach(doc => newStore.set(doc._id, doc));
+
+    const idIndexes = {};
+    freshIds.forEach((doc, index) => {
+      newStore.set(doc._id, doc);
+      idIndexes[newStore._idStringify(doc._id)] = index;
+    });
 
     let added = false;
     store.compareWith(newStore, {
+        both(docId, leftValue, rightValue) {
+          const beforeId = newStore._idStringify((freshIds[idIndexes[newStore._idStringify(docId)] + 1] || {})._id);
+          if (!EJSON.equals(leftValue, rightValue)) {
+            observableCollection.movedBefore(docId, beforeId);
+          }
+        },
         leftOnly(docId) {
             observableCollection.remove(docId);
         },
         rightOnly(docId) {
+          const beforeId = newStore._idStringify((freshIds[idIndexes[newStore._idStringify(docId)] + 1] || {})._id);
             if (newCommer && EJSON.equals(docId, newCommer._id)) {
                 added = true;
-                observableCollection.add(newCommer);
+                observableCollection.add(newCommer, false, beforeId);
             } else {
-                observableCollection.addById(docId);
+                observableCollection.addById(docId, beforeId);
             }
         }
     });


### PR DESCRIPTION
A potential solution to issue #309, might trigger too many `movedBefore` calls as it triggers one every time the document changes, even if the location has not. Open to better solutions here (e.g., storing the index in the IDMap)