### PR TITLE
After installing this package, an upsert always returns property `insertedId`

### DIFF
--- a/lib/mongo/Mutator.js
+++ b/lib/mongo/Mutator.js
@@ -189,28 +189,27 @@ export default class Mutator {
                 modifier,
                 _.extend({}, config, { _returnObject: true })
             );
-            let { insertedId, numberAffected } = data;
 
             if (callback) {
                 const self = this;
                 runCallbackInBackground(function() {
-                    callback.call(this, null, { insertedId, numberAffected });
+                    callback.call(this, null, data);
                 });
             }
 
             if (config.pushToRedis) {
-                if (insertedId) {
+                if (data.insertedId) {
                     dispatchInsert(
                         config.optimistic,
                         this._name,
                         config._channels,
-                        insertedId
+                        data.insertedId
                     );
                 } else {
                     // it means that we ran an upsert thinking there will be no docs
                     if (
                         docIds.length === 0 ||
-                        numberAffected !== docIds.length
+                        data.numberAffected !== docIds.length
                     ) {
                         // there were no docs initially found matching the selector
                         // however a document sneeked in, resulting in a race-condition
@@ -233,7 +232,7 @@ export default class Mutator {
                 }
             }
 
-            return { insertedId, numberAffected };
+            return data;
         } catch (e) {
             if (callback) {
                 const self = this;


### PR DESCRIPTION
Calling `collection.upsert()` usually returns an object, containing `numberAffected` and an optional `insertedId` which contains the id of the document created if no document was found to update.

When installing this package, the object returned will always contain both properties, `insertedId` being `undefined` if a document was found.

In my code, I checked - not for the value - but for the absence of the property, which got some of my logic to fail after installing this package.

I couldn't find any tests for this file - are the modifications tested to return the exact same result as Meteor would initially?