### PR TITLE
Replace practicalmeteor:chai with chai

### DIFF
--- a/lib/cache/testing/filterFieldsForFetching.test.js
+++ b/lib/cache/testing/filterFieldsForFetching.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {filterDisallowedFields, filterAllowedFields} from '../lib/filterFieldsForFetching';
 
 describe('Filter fields for fetching', function () {

--- a/lib/processors/testing/getStrategy.test.js
+++ b/lib/processors/testing/getStrategy.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import getStrategy from '../getStrategy';
 import { Strategy } from '../../constants';
 import { _ } from 'meteor/underscore';

--- a/lib/processors/testing/synthetic.test.js
+++ b/lib/processors/testing/synthetic.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import process from '../synthetic';
 import { Events } from '../../constants';
 import { MongoIDMap } from '../../cache/mongoIdMap';

--- a/lib/redis/testing/getFieldsOfInterestFromAll.js
+++ b/lib/redis/testing/getFieldsOfInterestFromAll.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { removeChildrenOfParents } from '../lib/getFieldsOfInterestFromAll';
 
 describe('#removeChildrenOfParents ', function() {

--- a/lib/utils/testing/extractIdsFromSelector.test.js
+++ b/lib/utils/testing/extractIdsFromSelector.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import run from '../extractIdsFromSelector';
 
 describe('Unit # extractIdsFromSelector', function () {

--- a/lib/utils/testing/getFields.test.js
+++ b/lib/utils/testing/getFields.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import run from '../getFields';
 
 describe('Unit # getFields', function () {

--- a/package.js
+++ b/package.js
@@ -1,64 +1,64 @@
 Package.describe({
-  name: 'cultofcoders:redis-oplog',
-  version: '2.0.0',
-  // Brief, one-line summary of the package.
-  summary: "Replacement for Meteor's MongoDB oplog implementation",
-  // URL to the Git repository containing the source code for this package.
-  git: 'https://github.com/cult-of-coders/redis-oplog',
-  // By default, Meteor will default to using README.md for documentation.
-  // To avoid submitting documentation, set this field to null.
-  documentation: 'README.md'
+    name: 'cultofcoders:redis-oplog',
+    version: '2.0.0',
+    // Brief, one-line summary of the package.
+    summary: "Replacement for Meteor's MongoDB oplog implementation",
+    // URL to the Git repository containing the source code for this package.
+    git: 'https://github.com/cult-of-coders/redis-oplog',
+    // By default, Meteor will default to using README.md for documentation.
+    // To avoid submitting documentation, set this field to null.
+    documentation: 'README.md'
 });
 
 Npm.depends({
-  redis: '2.8.0',
-  'deep-extend': '0.5.0',
-  'lodash.clonedeep': '4.5.0',
-  chai: '4.2.0'
+    redis: '2.8.0',
+    'deep-extend': '0.5.0',
+    'lodash.clonedeep': '4.5.0',
+    chai: '4.2.0'
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom('1.5.1');
-  api.use([
-    'underscore',
-    'ecmascript',
-    'ejson',
-    'minimongo',
-    'mongo',
-    'random',
-    'ddp-server',
-    'diff-sequence',
-    'id-map',
-    'mongo-id',
-    'tracker'
-  ]);
+    api.versionsFrom('1.5.1');
+    api.use([
+        'underscore',
+        'ecmascript',
+        'ejson',
+        'minimongo',
+        'mongo',
+        'random',
+        'ddp-server',
+        'diff-sequence',
+        'id-map',
+        'mongo-id',
+        'tracker'
+    ]);
 
-  api.mainModule('redis-oplog.js', 'server');
-  api.mainModule('redis-oplog.client.js', 'client');
+    api.mainModule('redis-oplog.js', 'server');
+    api.mainModule('redis-oplog.client.js', 'client');
 });
 
 Package.onTest(function(api) {
-  api.use('cultofcoders:redis-oplog');
+    api.use('cultofcoders:redis-oplog');
 
-  // extensions
-  api.use('aldeed:collection2@3.0.0');
-  api.use('reywood:publish-composite@1.5.2');
-  api.use('natestrauser:publish-performant-counts@0.1.2');
-  api.use('socialize:user-presence@0.4.0');
+    // extensions
+    api.use('aldeed:collection2@3.0.0');
+    api.use('reywood:publish-composite@1.5.2');
+    api.use('natestrauser:publish-performant-counts@0.1.2');
+    api.use('socialize:user-presence@0.4.0');
 
-  api.use('ecmascript');
-  api.use('tracker');
-  api.use('mongo');
-  api.use('random');
-  api.use('accounts-password');
-  api.use('matb33:collection-hooks@0.8.4');
-  api.use('alanning:roles@1.2.16');
+    api.use('ecmascript');
+    api.use('tracker');
+    api.use('mongo');
+    api.use('random');
+    api.use('accounts-password');
+    api.use('matb33:collection-hooks@0.8.4');
+    api.use('alanning:roles@1.2.16');
 
-  api.use(['meteortesting:mocha']);
+    api.use(['meteortesting:mocha']);
 
-  api.mainModule('testing/main.server.js', 'server');
-  api.addFiles('testing/publishComposite/boot.js', 'server');
-  api.addFiles('testing/optimistic-ui/boot.js', 'server');
+    api.mainModule('testing/main.server.js', 'server');
+    api.addFiles('testing/publishComposite/boot.js', 'server');
+    api.addFiles('testing/optimistic-ui/boot.js', 'server');
 
-  api.mainModule('testing/main.client.js', 'client');
+    api.mainModule('testing/main.client.js', 'client');
 });

--- a/package.js
+++ b/package.js
@@ -13,7 +13,8 @@ Package.describe({
 Npm.depends({
   redis: '2.8.0',
   'deep-extend': '0.5.0',
-  'lodash.clonedeep': '4.5.0'
+  'lodash.clonedeep': '4.5.0',
+  chai: '4.2.0'
 });
 
 Package.onUse(function(api) {

--- a/package.js
+++ b/package.js
@@ -1,63 +1,63 @@
 Package.describe({
-    name: 'cultofcoders:redis-oplog',
-    version: '2.0.0',
-    // Brief, one-line summary of the package.
-    summary: "Replacement for Meteor's MongoDB oplog implementation",
-    // URL to the Git repository containing the source code for this package.
-    git: 'https://github.com/cult-of-coders/redis-oplog',
-    // By default, Meteor will default to using README.md for documentation.
-    // To avoid submitting documentation, set this field to null.
-    documentation: 'README.md',
+  name: 'cultofcoders:redis-oplog',
+  version: '2.0.0',
+  // Brief, one-line summary of the package.
+  summary: "Replacement for Meteor's MongoDB oplog implementation",
+  // URL to the Git repository containing the source code for this package.
+  git: 'https://github.com/cult-of-coders/redis-oplog',
+  // By default, Meteor will default to using README.md for documentation.
+  // To avoid submitting documentation, set this field to null.
+  documentation: 'README.md'
 });
 
 Npm.depends({
-    redis: '2.8.0',
-    'deep-extend': '0.5.0',
-    'lodash.clonedeep': '4.5.0',
+  redis: '2.8.0',
+  'deep-extend': '0.5.0',
+  'lodash.clonedeep': '4.5.0'
 });
 
 Package.onUse(function(api) {
-    api.versionsFrom('1.5.1');
-    api.use([
-        'underscore',
-        'ecmascript',
-        'ejson',
-        'minimongo',
-        'mongo',
-        'random',
-        'ddp-server',
-        'diff-sequence',
-        'id-map',
-        'mongo-id',
-        'tracker',
-    ]);
+  api.versionsFrom('1.5.1');
+  api.use([
+    'underscore',
+    'ecmascript',
+    'ejson',
+    'minimongo',
+    'mongo',
+    'random',
+    'ddp-server',
+    'diff-sequence',
+    'id-map',
+    'mongo-id',
+    'tracker'
+  ]);
 
-    api.mainModule('redis-oplog.js', 'server');
-    api.mainModule('redis-oplog.client.js', 'client');
+  api.mainModule('redis-oplog.js', 'server');
+  api.mainModule('redis-oplog.client.js', 'client');
 });
 
 Package.onTest(function(api) {
-    api.use('cultofcoders:redis-oplog');
+  api.use('cultofcoders:redis-oplog');
 
-    // extensions
-    api.use('aldeed:collection2@3.0.0');
-    api.use('reywood:publish-composite@1.5.2');
-    api.use('natestrauser:publish-performant-counts@0.1.2');
-    api.use('socialize:user-presence@0.4.0');
+  // extensions
+  api.use('aldeed:collection2@3.0.0');
+  api.use('reywood:publish-composite@1.5.2');
+  api.use('natestrauser:publish-performant-counts@0.1.2');
+  api.use('socialize:user-presence@0.4.0');
 
-    api.use('ecmascript');
-    api.use('tracker');
-    api.use('mongo');
-    api.use('random');
-    api.use('accounts-password');
-    api.use('matb33:collection-hooks@0.8.4');
-    api.use('alanning:roles@1.2.16');
+  api.use('ecmascript');
+  api.use('tracker');
+  api.use('mongo');
+  api.use('random');
+  api.use('accounts-password');
+  api.use('matb33:collection-hooks@0.8.4');
+  api.use('alanning:roles@1.2.16');
 
-    api.use(['meteortesting:mocha', 'practicalmeteor:chai']);
+  api.use(['meteortesting:mocha']);
 
-    api.mainModule('testing/main.server.js', 'server');
-    api.addFiles('testing/publishComposite/boot.js', 'server');
-    api.addFiles('testing/optimistic-ui/boot.js', 'server');
+  api.mainModule('testing/main.server.js', 'server');
+  api.addFiles('testing/publishComposite/boot.js', 'server');
+  api.addFiles('testing/optimistic-ui/boot.js', 'server');
 
-    api.mainModule('testing/main.client.js', 'client');
+  api.mainModule('testing/main.client.js', 'client');
 });

--- a/testing/accounts/client.js
+++ b/testing/accounts/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Meteor} from 'meteor/meteor';
 import { DDP } from 'meteor/ddp-client';
 

--- a/testing/client_side_mutators.js
+++ b/testing/client_side_mutators.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Collections, config} from './boot';
 import helperGenerator from './lib/helpers';
 

--- a/testing/collection-defaults/client.js
+++ b/testing/collection-defaults/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Items} from './collections';
 import {_} from 'meteor/underscore';
 import {waitForHandleToBeReady, callWithPromise} from '../lib/sync_utils';

--- a/testing/collection_hooks.server.js
+++ b/testing/collection_hooks.server.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { _ } from 'meteor/underscore';
 import { Random } from 'meteor/random';
 

--- a/testing/collection_transform.js
+++ b/testing/collection_transform.js
@@ -1,4 +1,6 @@
+import { assert } from 'chai';
 function Foo () {}
+
 const fooCollection = new Mongo.Collection('foo', {
     transform: function(document) {
         return new Foo(document)

--- a/testing/custom-publications/client.js
+++ b/testing/custom-publications/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Items} from './collections';
 import {Meteor} from 'meteor/meteor';
 import {Counter} from 'meteor/natestrauser:publish-performant-counts'

--- a/testing/initial_add.js
+++ b/testing/initial_add.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Mongo} from 'meteor/mongo';
 
 const InitialAddCollection = new Mongo.Collection('initial_add')

--- a/testing/main.client.js
+++ b/testing/main.client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { Collections, config } from './boot';
 import { _ } from 'meteor/underscore';
 import './synthetic_mutators';

--- a/testing/object-id/client.js
+++ b/testing/object-id/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { SmartIds } from './collections';
 import { Meteor } from 'meteor/meteor';
 

--- a/testing/observe_callbacks.server.js
+++ b/testing/observe_callbacks.server.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { Mongo } from 'meteor/mongo';
 
 const Collection = new Mongo.Collection('test_observe_callbacks');

--- a/testing/optimistic-ui/client.test.js
+++ b/testing/optimistic-ui/client.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { Items } from './collections';
 import { _ } from 'meteor/underscore';
 import { waitForHandleToBeReady, callWithPromise } from '../lib/sync_utils';

--- a/testing/polling/client.js
+++ b/testing/polling/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { Campaigns } from './collections';
 import { Meteor } from 'meteor/meteor';
 

--- a/testing/publish-counts/client.js
+++ b/testing/publish-counts/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Items} from './collections';
 import {Meteor} from 'meteor/meteor';
 import {Counter} from 'meteor/natestrauser:publish-performant-counts'

--- a/testing/publishComposite/client.test.js
+++ b/testing/publishComposite/client.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Items, Children} from './collections';
 import {_} from 'meteor/underscore';
 import {waitForHandleToBeReady, callWithPromise} from '../lib/sync_utils';

--- a/testing/server-autorun/client.js
+++ b/testing/server-autorun/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Orders, Items} from './collections';
 import {Meteor} from 'meteor/meteor';
 

--- a/testing/synthetic_mutators.js
+++ b/testing/synthetic_mutators.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { Collections, config } from './boot';
 import { Random } from 'meteor/random';
 import { _ } from 'meteor/underscore';

--- a/testing/transformations/client.js
+++ b/testing/transformations/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Items} from './collections';
 
 describe('Transformations', function () {

--- a/testing/transformations/server.js
+++ b/testing/transformations/server.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { Items } from './collections';
 
 Meteor.publish('transformations_items', function() {

--- a/testing/vent/client.js
+++ b/testing/vent/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {waitForHandleToBeReady, callWithPromise} from '../lib/sync_utils';
 import {Random} from 'meteor/random';
 import {Vent} from 'meteor/cultofcoders:redis-oplog';


### PR DESCRIPTION
The `practicalmeteor:chai` package prevents us from updating to 2.0.0. This replaces it with the regular `chai` package