### PR TITLE
Fix to call collection callbacks if externalRedisPublisher is enabled

### DIFF
--- a/lib/mongo/Mutator.js
+++ b/lib/mongo/Mutator.js
@@ -36,7 +36,7 @@ export default class Mutator {
         });
 
         if (canUseOriginalMethod(config)) {
-            return Originals.insert.call(this, data);
+            return Originals.insert.call(this, data, _.isFunction(_config) ? _config : undefined);
         }
 
         try {
@@ -94,7 +94,7 @@ export default class Mutator {
         });
 
         if (canUseOriginalMethod(config)) {
-            return Originals.update.call(this, selector, modifier, config);
+            return Originals.update.call(this, selector, modifier, _config, callback);
         }
 
         // searching the elements that will get updated by id
@@ -267,7 +267,7 @@ export default class Mutator {
         });
 
         if (canUseOriginalMethod(config)) {
-            return Originals.remove.call(this, selector);
+            return Originals.remove.call(this, selector, _.isFunction(_config) ? _config : undefined);
         }
 
         const removeSelector = _.extend({}, selector);


### PR DESCRIPTION
As in #314, I don't know if or how I should set up a test-environment for this use-case, but these are vital. They ensure that all the arguments are given to the underlying meteor method.