### PR TITLE
Fixed crash on remove if selector was undefined

### DIFF
--- a/lib/mongo/Mutator.js
+++ b/lib/mongo/Mutator.js
@@ -257,9 +257,7 @@ export default class Mutator {
      * @returns {*}
      */
     static remove(Originals, selector, _config) {
-        if (_.isString(selector)) {
-            selector = { _id: selector };
-        }
+        selector = Mongo.Collection._rewriteSelector(selector);
 
         const config = getMutationConfig(this, _config, {
             selector,


### PR DESCRIPTION
Can be reproduced by initializing this plugin and using an empty selector in a remove command:

```js
const collection = new Mongo.Collection('dummy');
collection.remove();
```