### PR TITLE
Added the count of deleted items to the `remove` callback

### DIFF
--- a/lib/mongo/Mutator.js
+++ b/lib/mongo/Mutator.js
@@ -295,7 +295,7 @@ export default class Mutator {
             if (_.isFunction(_config)) {
                 const self = this;
                 runCallbackInBackground(function() {
-                    _config.call(self, null);
+                    _config.call(self, null, result);
                 });
             }
 


### PR DESCRIPTION
Can be reproduced by initializing this plugin and using a callback in the remove command to retrieve the number of removed documents:

```js
const collection = new Mongo.Collection('dummy');
collection.remove({}, function (error, count) {
    console.log(count); // is always undefined
});
```