### PR TITLE
Use chai by npm and replace chrome by puppeteer

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,20 +1,25 @@
 {
   "lockfileVersion": 1,
   "dependencies": {
-    "base64-js": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
-      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w=="
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
-    "buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
-      "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw=="
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw=="
     },
-    "deep-diff": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
-      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw=="
     },
     "deep-extend": {
       "version": "0.5.0",
@@ -26,20 +31,20 @@
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
-    "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
-    "object-sizeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/object-sizeof/-/object-sizeof-1.2.0.tgz",
-      "integrity": "sha1-Zjl8kjdok50vxtKjkwqYHhx/pos="
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
     "redis": {
       "version": "2.8.0",
@@ -47,14 +52,19 @@
       "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A=="
     },
     "redis-commands": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.3.tgz",
-      "integrity": "sha512-i41GK1SzbNp5nqmuVAMQw9sgar/cvk4YqD6M2RXp2p94D4itY82OZGVs28Jl8JcslGnOdQvlBrDLPt6jYQzuow=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
+      "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
     },
     "redis-parser": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
       "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     }
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   - sleep 3
 
 script:
-  - meteor create --release 1.8.1-rc.1 --bare test
+  - meteor create --release 1.8.1 --bare test
   - cd test
   - meteor npm i --save selenium-webdriver@3.6.0 chromedriver@2.36.0 simpl-schema
   - METEOR_PACKAGE_DIRS="../" TEST_BROWSER_DRIVER=chrome meteor test-packages --once --driver-package meteortesting:mocha ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
-sudo: required
 services:
   - redis-server
-
-addons:
-  chrome: stable
 
 language: node_js
 
@@ -17,18 +13,13 @@ before_install:
 cache:
   directories:
     - ~/.npm
-    - "node_modules"
+    - ~/.meteor
 
 notifications:
   email: false
 
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3
-
 script:
   - meteor create --release 1.8.1 --bare test
   - cd test
-  - meteor npm i --save selenium-webdriver@3.6.0 chromedriver@2.36.0 simpl-schema
-  - METEOR_PACKAGE_DIRS="../" TEST_BROWSER_DRIVER=chrome meteor test-packages --once --driver-package meteortesting:mocha ../
+  - meteor npm i --save puppeteer@1.18.1 simpl-schema
+  - METEOR_PACKAGE_DIRS="../" TEST_BROWSER_DRIVER=puppeteer meteor test-packages --raw-logs --once --driver-package meteortesting:mocha ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_install:
 
 cache:
   directories:
-    - ~/.npm
-    - ~/.meteor
+    - $HOME/.npm
+    - $HOME/.meteor
 
 notifications:
   email: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,12 +30,12 @@ It is also always helpful to have some context for your pull request. What was t
 ```
 meteor create --release 1.8.1 --bare test
 cd test
-meteor npm i --save selenium-webdriver@3.6.0 chromedriver@2.36.0 simpl-schema
+meteor npm i --save puppeteer@1.18.1 simpl-schema
 ```
 
 ### Start Tests
 ```
-METEOR_PACKAGE_DIRS="../" TEST_BROWSER_DRIVER=chrome meteor test-packages --once --driver-package meteortesting:mocha ../
+METEOR_PACKAGE_DIRS="../" TEST_BROWSER_DRIVER=puppeteer meteor test-packages --raw-logs --once --driver-package meteortesting:mocha ../
 ```
 
 ## Financial contributions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ It is also always helpful to have some context for your pull request. What was t
 
 ### Setup 
 ```
-meteor create --release 1.8.1-rc.1 --bare test
+meteor create --release 1.8.1 --bare test
 cd test
 meteor npm i --save selenium-webdriver@3.6.0 chromedriver@2.36.0 simpl-schema
 ```

--- a/lib/cache/testing/filterFieldsForFetching.test.js
+++ b/lib/cache/testing/filterFieldsForFetching.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {filterDisallowedFields, filterAllowedFields} from '../lib/filterFieldsForFetching';
 
 describe('Filter fields for fetching', function () {

--- a/lib/processors/testing/getStrategy.test.js
+++ b/lib/processors/testing/getStrategy.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import getStrategy from '../getStrategy';
 import { Strategy } from '../../constants';
 import { _ } from 'meteor/underscore';

--- a/lib/processors/testing/synthetic.test.js
+++ b/lib/processors/testing/synthetic.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import process from '../synthetic';
 import { Events } from '../../constants';
 import { MongoIDMap } from '../../cache/mongoIdMap';

--- a/lib/redis/testing/getFieldsOfInterestFromAll.js
+++ b/lib/redis/testing/getFieldsOfInterestFromAll.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { removeChildrenOfParents } from '../lib/getFieldsOfInterestFromAll';
 
 describe('#removeChildrenOfParents ', function() {

--- a/lib/utils/testing/extractIdsFromSelector.test.js
+++ b/lib/utils/testing/extractIdsFromSelector.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import run from '../extractIdsFromSelector';
 
 describe('Unit # extractIdsFromSelector', function () {

--- a/lib/utils/testing/getFields.test.js
+++ b/lib/utils/testing/getFields.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import run from '../getFields';
 
 describe('Unit # getFields', function () {

--- a/package.js
+++ b/package.js
@@ -1,64 +1,64 @@
 Package.describe({
-  name: 'cultofcoders:redis-oplog',
-  version: '2.0.0',
-  // Brief, one-line summary of the package.
-  summary: "Replacement for Meteor's MongoDB oplog implementation",
-  // URL to the Git repository containing the source code for this package.
-  git: 'https://github.com/cult-of-coders/redis-oplog',
-  // By default, Meteor will default to using README.md for documentation.
-  // To avoid submitting documentation, set this field to null.
-  documentation: 'README.md'
+    name: 'cultofcoders:redis-oplog',
+    version: '2.0.0',
+    // Brief, one-line summary of the package.
+    summary: "Replacement for Meteor's MongoDB oplog implementation",
+    // URL to the Git repository containing the source code for this package.
+    git: 'https://github.com/cult-of-coders/redis-oplog',
+    // By default, Meteor will default to using README.md for documentation.
+    // To avoid submitting documentation, set this field to null.
+    documentation: 'README.md'
 });
 
 Npm.depends({
-  redis: '2.8.0',
-  'deep-extend': '0.5.0',
-  'lodash.clonedeep': '4.5.0',
-  chai: '4.2.0'
+    redis: '2.8.0',
+    'deep-extend': '0.5.0',
+    'lodash.clonedeep': '4.5.0',
+    chai: '4.2.0'
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom('1.5.1');
-  api.use([
-    'underscore',
-    'ecmascript',
-    'ejson',
-    'minimongo',
-    'mongo',
-    'random',
-    'ddp-server',
-    'diff-sequence',
-    'id-map',
-    'mongo-id',
-    'tracker'
-  ]);
+    api.versionsFrom('1.5.1');
+    api.use([
+        'underscore',
+        'ecmascript',
+        'ejson',
+        'minimongo',
+        'mongo',
+        'random',
+        'ddp-server',
+        'diff-sequence',
+        'id-map',
+        'mongo-id',
+        'tracker'
+    ]);
 
-  api.mainModule('redis-oplog.js', 'server');
-  api.mainModule('redis-oplog.client.js', 'client');
+    api.mainModule('redis-oplog.js', 'server');
+    api.mainModule('redis-oplog.client.js', 'client');
 });
 
 Package.onTest(function(api) {
-  api.use('cultofcoders:redis-oplog');
+    api.use('cultofcoders:redis-oplog');
 
-  // extensions
-  api.use('aldeed:collection2@3.0.0');
-  api.use('reywood:publish-composite@1.5.2');
-  api.use('natestrauser:publish-performant-counts@0.1.2');
-  api.use('socialize:user-presence@0.4.0');
+    // extensions
+    api.use('aldeed:collection2@3.0.0');
+    api.use('reywood:publish-composite@1.5.2');
+    api.use('natestrauser:publish-performant-counts@0.1.2');
+    api.use('socialize:user-presence@0.4.0');
 
-  api.use('ecmascript');
-  api.use('tracker');
-  api.use('mongo');
-  api.use('random');
-  api.use('accounts-password');
-  api.use('matb33:collection-hooks@0.8.4');
-  api.use('alanning:roles@1.2.16');
+    api.use('ecmascript');
+    api.use('tracker');
+    api.use('mongo');
+    api.use('random');
+    api.use('accounts-password');
+    api.use('matb33:collection-hooks@0.8.4');
+    api.use('alanning:roles@1.2.16');
 
-  api.use(['meteortesting:mocha']);
+    api.use(['meteortesting:mocha']);
 
-  api.mainModule('testing/main.server.js', 'server');
-  api.addFiles('testing/publishComposite/boot.js', 'server');
-  api.addFiles('testing/optimistic-ui/boot.js', 'server');
+    api.mainModule('testing/main.server.js', 'server');
+    api.addFiles('testing/publishComposite/boot.js', 'server');
+    api.addFiles('testing/optimistic-ui/boot.js', 'server');
 
-  api.mainModule('testing/main.client.js', 'client');
+    api.mainModule('testing/main.client.js', 'client');
 });

--- a/package.js
+++ b/package.js
@@ -13,7 +13,8 @@ Package.describe({
 Npm.depends({
   redis: '2.8.0',
   'deep-extend': '0.5.0',
-  'lodash.clonedeep': '4.5.0'
+  'lodash.clonedeep': '4.5.0',
+  chai: '4.2.0'
 });
 
 Package.onUse(function(api) {

--- a/package.js
+++ b/package.js
@@ -1,63 +1,63 @@
 Package.describe({
-    name: 'cultofcoders:redis-oplog',
-    version: '2.0.0',
-    // Brief, one-line summary of the package.
-    summary: "Replacement for Meteor's MongoDB oplog implementation",
-    // URL to the Git repository containing the source code for this package.
-    git: 'https://github.com/cult-of-coders/redis-oplog',
-    // By default, Meteor will default to using README.md for documentation.
-    // To avoid submitting documentation, set this field to null.
-    documentation: 'README.md',
+  name: 'cultofcoders:redis-oplog',
+  version: '2.0.0',
+  // Brief, one-line summary of the package.
+  summary: "Replacement for Meteor's MongoDB oplog implementation",
+  // URL to the Git repository containing the source code for this package.
+  git: 'https://github.com/cult-of-coders/redis-oplog',
+  // By default, Meteor will default to using README.md for documentation.
+  // To avoid submitting documentation, set this field to null.
+  documentation: 'README.md'
 });
 
 Npm.depends({
-    redis: '2.8.0',
-    'deep-extend': '0.5.0',
-    'lodash.clonedeep': '4.5.0',
+  redis: '2.8.0',
+  'deep-extend': '0.5.0',
+  'lodash.clonedeep': '4.5.0'
 });
 
 Package.onUse(function(api) {
-    api.versionsFrom('1.5.1');
-    api.use([
-        'underscore',
-        'ecmascript',
-        'ejson',
-        'minimongo',
-        'mongo',
-        'random',
-        'ddp-server',
-        'diff-sequence',
-        'id-map',
-        'mongo-id',
-        'tracker',
-    ]);
+  api.versionsFrom('1.5.1');
+  api.use([
+    'underscore',
+    'ecmascript',
+    'ejson',
+    'minimongo',
+    'mongo',
+    'random',
+    'ddp-server',
+    'diff-sequence',
+    'id-map',
+    'mongo-id',
+    'tracker'
+  ]);
 
-    api.mainModule('redis-oplog.js', 'server');
-    api.mainModule('redis-oplog.client.js', 'client');
+  api.mainModule('redis-oplog.js', 'server');
+  api.mainModule('redis-oplog.client.js', 'client');
 });
 
 Package.onTest(function(api) {
-    api.use('cultofcoders:redis-oplog');
+  api.use('cultofcoders:redis-oplog');
 
-    // extensions
-    api.use('aldeed:collection2@3.0.0');
-    api.use('reywood:publish-composite@1.5.2');
-    api.use('natestrauser:publish-performant-counts@0.1.2');
-    api.use('socialize:user-presence@0.4.0');
+  // extensions
+  api.use('aldeed:collection2@3.0.0');
+  api.use('reywood:publish-composite@1.5.2');
+  api.use('natestrauser:publish-performant-counts@0.1.2');
+  api.use('socialize:user-presence@0.4.0');
 
-    api.use('ecmascript');
-    api.use('tracker');
-    api.use('mongo');
-    api.use('random');
-    api.use('accounts-password');
-    api.use('matb33:collection-hooks@0.8.4');
-    api.use('alanning:roles@1.2.16');
+  api.use('ecmascript');
+  api.use('tracker');
+  api.use('mongo');
+  api.use('random');
+  api.use('accounts-password');
+  api.use('matb33:collection-hooks@0.8.4');
+  api.use('alanning:roles@1.2.16');
 
-    api.use(['meteortesting:mocha', 'practicalmeteor:chai']);
+  api.use(['meteortesting:mocha']);
 
-    api.mainModule('testing/main.server.js', 'server');
-    api.addFiles('testing/publishComposite/boot.js', 'server');
-    api.addFiles('testing/optimistic-ui/boot.js', 'server');
+  api.mainModule('testing/main.server.js', 'server');
+  api.addFiles('testing/publishComposite/boot.js', 'server');
+  api.addFiles('testing/optimistic-ui/boot.js', 'server');
 
-    api.mainModule('testing/main.client.js', 'client');
+  api.mainModule('testing/main.client.js', 'client');
 });

--- a/testing/accounts/client.js
+++ b/testing/accounts/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Meteor} from 'meteor/meteor';
 import { DDP } from 'meteor/ddp-client';
 

--- a/testing/client_side_mutators.js
+++ b/testing/client_side_mutators.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Collections, config} from './boot';
 import helperGenerator from './lib/helpers';
 

--- a/testing/collection-defaults/client.js
+++ b/testing/collection-defaults/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Items} from './collections';
 import {_} from 'meteor/underscore';
 import {waitForHandleToBeReady, callWithPromise} from '../lib/sync_utils';

--- a/testing/collection_hooks.server.js
+++ b/testing/collection_hooks.server.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { _ } from 'meteor/underscore';
 import { Random } from 'meteor/random';
 

--- a/testing/collection_transform.js
+++ b/testing/collection_transform.js
@@ -1,4 +1,6 @@
+import { assert } from 'chai';
 function Foo () {}
+
 const fooCollection = new Mongo.Collection('foo', {
     transform: function(document) {
         return new Foo(document)

--- a/testing/custom-publications/client.js
+++ b/testing/custom-publications/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Items} from './collections';
 import {Meteor} from 'meteor/meteor';
 import {Counter} from 'meteor/natestrauser:publish-performant-counts'

--- a/testing/include_prev_doc.js
+++ b/testing/include_prev_doc.js
@@ -1,3 +1,5 @@
+import { assert } from 'chai';
+
 import { Mongo } from 'meteor/mongo';
 import { _ } from 'meteor/underscore';
 import Config from '../lib/config';

--- a/testing/initial_add.js
+++ b/testing/initial_add.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Mongo} from 'meteor/mongo';
 
 const InitialAddCollection = new Mongo.Collection('initial_add')

--- a/testing/main.client.js
+++ b/testing/main.client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { Collections, config } from './boot';
 import { _ } from 'meteor/underscore';
 import './synthetic_mutators';

--- a/testing/object-id/client.js
+++ b/testing/object-id/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { SmartIds } from './collections';
 import { Meteor } from 'meteor/meteor';
 

--- a/testing/observe_callbacks.server.js
+++ b/testing/observe_callbacks.server.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { Mongo } from 'meteor/mongo';
 
 const Collection = new Mongo.Collection('test_observe_callbacks');

--- a/testing/optimistic-ui/client.test.js
+++ b/testing/optimistic-ui/client.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { Items } from './collections';
 import { _ } from 'meteor/underscore';
 import { waitForHandleToBeReady, callWithPromise } from '../lib/sync_utils';

--- a/testing/polling/client.js
+++ b/testing/polling/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { Campaigns } from './collections';
 import { Meteor } from 'meteor/meteor';
 

--- a/testing/publish-counts/client.js
+++ b/testing/publish-counts/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Items} from './collections';
 import {Meteor} from 'meteor/meteor';
 import {Counter} from 'meteor/natestrauser:publish-performant-counts'

--- a/testing/publishComposite/client.test.js
+++ b/testing/publishComposite/client.test.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Items, Children} from './collections';
 import {_} from 'meteor/underscore';
 import {waitForHandleToBeReady, callWithPromise} from '../lib/sync_utils';

--- a/testing/server-autorun/client.js
+++ b/testing/server-autorun/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Orders, Items} from './collections';
 import {Meteor} from 'meteor/meteor';
 

--- a/testing/synthetic_mutators.js
+++ b/testing/synthetic_mutators.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { Collections, config } from './boot';
 import { Random } from 'meteor/random';
 import { _ } from 'meteor/underscore';

--- a/testing/transformations/client.js
+++ b/testing/transformations/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {Items} from './collections';
 
 describe('Transformations', function () {

--- a/testing/transformations/server.js
+++ b/testing/transformations/server.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import { Items } from './collections';
 
 Meteor.publish('transformations_items', function() {

--- a/testing/vent/client.js
+++ b/testing/vent/client.js
@@ -1,3 +1,4 @@
+import { assert } from 'chai';
 import {waitForHandleToBeReady, callWithPromise} from '../lib/sync_utils';
 import {Random} from 'meteor/random';
 import {Vent} from 'meteor/cultofcoders:redis-oplog';


### PR DESCRIPTION
Includes all changes of #316, adds one missing import-statement.

In addition I tried to switch the selenium based chrome test-driver over to puppeteer, which does not require root access or an installation of google chrome.