### PR TITLE
Delete a multiplexer when it's init fails for any reason

### DIFF
--- a/lib/mongo/observeChanges.js
+++ b/lib/mongo/observeChanges.js
@@ -120,19 +120,25 @@ export default function(cursorDescription, ordered, callbacks) {
             ? RedisOplogObserveDriver
             : PollingObserveDriver;
 
-        observeDriver = new driverClass({
-            cursorDescription: cursorDescription,
-            mongoHandle: self,
-            multiplexer: multiplexer,
-            ordered: ordered,
-            matcher: matcher,
-            // ignored by polling
-            sorter: sorter,
-            // ignored by polling
-            _testOnlyPollCallback: callbacks._testOnlyPollCallback,
-        }); // This field is only set for use in tests.
+        try {
+          observeDriver = new driverClass({
+              cursorDescription: cursorDescription,
+              mongoHandle: self,
+              multiplexer: multiplexer,
+              ordered: ordered,
+              matcher: matcher,
+              // ignored by polling
+              sorter: sorter,
+              // ignored by polling
+              _testOnlyPollCallback: callbacks._testOnlyPollCallback,
+          }); // This field is only set for use in tests.
 
-        multiplexer._observeDriver = observeDriver;
+          multiplexer._observeDriver = observeDriver;
+        }
+        catch (e) {
+          console.error(e);
+          delete self._observeMultiplexers[observeKey];
+        }
     }
 
     // Blocks until the initial adds have been sent.


### PR DESCRIPTION
This fixes what I consider to be a critical bug. 

In the case that the initial fetch fails on ObservableCollection.js:172 (`let data = this.cursor.fetch();`) which can happen for any number of reasons (e.g., primary failover, timeout, DB server crash, etc) ALL subsequent observes using the same query will HANG - not fail. As such subscriptions that trigger this bug will block the client from making ANY requests to the server.

It would be amazing if we could merge this in quickly - this is a bug that has haunted us since we started using redis-oplog (which is an amazing package!). Only this morning was I finally able to get some logs and a concrete case.

You can replicate this behaviour trivially by throwing any error from here: ObservableCollection.js:171