### PR TITLE
Update redis package version to 3.0.2

### DIFF
--- a/package.js
+++ b/package.js
@@ -11,7 +11,7 @@ Package.describe({
 });
 
 Npm.depends({
-    redis: '2.8.0',
+    redis: '3.0.2',
     'deep-extend': '0.5.0',
     'lodash.clonedeep': '4.5.0'
 });


### PR DESCRIPTION
Changelog: https://github.com/NodeRedis/node-redis/blob/master/CHANGELOG.md#v300---09-feb-2020

Most notable changes are added support for rediss protocol in url and dropped support for Node.js < 6.