### PR TITLE
disableMongo configuration for Vent-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Configure it via Meteor settings:
         "pushToRedis": true // Pushes to redis the changes by default
     },
     "debug": false, // Will show timestamp and activity of redis-oplog.
+    "disableMongo": false // Set to true to disable redis-oplog's Mongo functionality. Useful if you just want to use Vent.
   }
 }
 ```

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,7 +4,7 @@
 let Config = {
     isInitialized: false,
     debug: false,
-    overridePublishFunction: true,
+    disableMongo: false,
     mutationDefaults: {
         pushToRedis: true,
         optimistic: true,

--- a/lib/init.js
+++ b/lib/init.js
@@ -23,7 +23,9 @@ export default (config = {}) => {
         oldPublish: Meteor.publish,
     });
 
-    extendMongoCollection();
+    if (!Config.disableMongo) {
+        extendMongoCollection();
+    }
 
     // this initializes the listener singleton with the proper onConnect functionality
     getRedisListener({

--- a/testing/boot.js
+++ b/testing/boot.js
@@ -8,7 +8,6 @@ if (Meteor.isServer) {
             port: 6379, // Redis port
             host: '127.0.0.1', // Redis host
         },
-        // overridePublishFunction: true
         // debug: true
     });
 }


### PR DESCRIPTION
Adds a `disableMongo` configuration option for disabling all the Mongo overrides, but still connecting to the Redis server, which I gather from #359 and #361 is useful for just using Vent.

Fix #359, fix #361, and sort of relevant to #323.