### PR TITLE
fix: ignore undefined and null params on modifiers

### DIFF
--- a/.versions
+++ b/.versions
@@ -10,7 +10,6 @@ binary-heap@1.0.11
 boilerplate-generator@1.7.1
 callback-hook@1.5.1
 check@1.3.2
-cultofcoders:redis-oplog@2.2.1
 ddp@1.4.1
 ddp-client@2.6.1
 ddp-common@1.4.0
@@ -28,7 +27,7 @@ fetch@0.1.3
 geojson-utils@1.0.11
 id-map@1.1.1
 inter-process-messaging@0.1.1
-local-test:cultofcoders:redis-oplog@2.2.1
+local-test:networksforchange:redis-oplog@2.2.3
 localstorage@1.2.0
 logging@1.3.2
 matb33:collection-hooks@1.1.4
@@ -44,6 +43,7 @@ mongo-decimal@0.1.3
 mongo-dev-server@1.1.0
 mongo-id@1.0.8
 natestrauser:publish-performant-counts@0.1.2
+networksforchange:redis-oplog@2.2.3
 npm-mongo@4.16.0
 ordered-dict@1.1.0
 practicalmeteor:mocha-core@1.0.1

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-## Introducing BlueLibs
-
-- [GitHub BlueLibs Monorepo](https://github.com/bluelibs/bluelibs)
-- Following the same bold vision of Meteor, but with a modern twist. www.bluelibs.com
-- Read more about our approach coming from Meteor: https://www.bluelibs.com/blog/2021/11/26/the-meteor-of-2022
-- We've implemented [RedisOplog](https://www.bluelibs.com/docs/package-x-bundle#live-data) in our framework as well, but it also works with in-memory and with customisable pubsub, not bound to redis.
-
 # Welcome to Redis Oplog
 
 ### LICENSE: MIT
 
 [![Backers on Open Collective](https://opencollective.com/redis-oplog/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/redis-oplog/sponsors/badge.svg)](#sponsors)
+
+## Pushing to Meteor Atmosphere 
+
+```bash
+meteor publish --release 2.13 
+```
 
 ## RedisOplog
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,3 +1,6 @@
+import log from "./log";
+import error from "./error";
+
 /**
  * In-Memory configuration storage
  */
@@ -16,6 +19,7 @@ let Config = {
     },
     globalRedisPrefix: '',
     retryIntervalMs: 10000,
+    pingIntervalMs: 30000,
     externalRedisPublisher: false,
     redisExtras: {
         retry_strategy: function(options) {
@@ -28,18 +32,18 @@ let Config = {
                 console.error('RedisOplog - Connection to redis ended');
             },
             error(err) {
-                console.error(
+                error(
                     `RedisOplog - An error occured: \n`,
                     JSON.stringify(err)
                 );
             },
             connect(err) {
                 if (!err) {
-                    console.log(
+                    log(
                         'RedisOplog - Established connection to redis.'
                     );
                 } else {
-                    console.error(
+                    error(
                         'RedisOplog - There was an error when connecting to redis',
                         JSON.stringify(err)
                     );
@@ -47,7 +51,7 @@ let Config = {
             },
             reconnecting(err) {
                 if (err) {
-                    console.error(
+                    error(
                         'RedisOplog - There was an error when re-connecting to redis',
                         JSON.stringify(err)
                     );

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -2,8 +2,8 @@ import Config from './config';
 
 export default (message, trace = false) => {
     if (Config.debug) {
-        const timestamp = (new Date()).getTime();
-        console.log(`[${timestamp}] - ` + message);
+        const dateTimeInUtc = new Date().toUTCString();
+        console.log(`[${dateTimeInUtc}] - ` + message);
 
         if (trace) {
             console.log(trace);

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,0 +1,4 @@
+export default (message, error) => {
+    const dateTimeInUtc = new Date().toUTCString();
+    console.error(`[${dateTimeInUtc}] - ` + message, error);
+}

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,5 @@
+export default (message) => {
+    const dateTimeInUtc = new Date().toUTCString();
+    console.log(`[${dateTimeInUtc}] - ` + message);
+
+}

--- a/lib/redis/getRedisClient.js
+++ b/lib/redis/getRedisClient.js
@@ -1,10 +1,33 @@
 import redis from 'redis';
 import Config from '../config';
 import { Meteor } from 'meteor/meteor';
+import debug from "../debug";
 
 // Redis requires two connections for pushing and listening to data
 let redisPusher;
 let redisListener;
+
+function attachPingTimerEvents(client) {
+    if(!Config.pingIntervalMs || Config.pingIntervalMs <= 0) return;
+    let pingTimer = null;
+    client.on('connect', function(err) {
+        if(err) return;
+        debug('RedisOplog - Ping timer connected');
+        pingTimer = setInterval(() => {
+            debug('RedisOplog - Pinging redis');
+            client.ping();
+        }, Config.pingIntervalMs);
+    });
+
+    client.on('end', function() {
+        debug('RedisOplog - Ping timer ended');
+        if(pingTimer) {
+            clearInterval(pingTimer);
+            pingTimer = null;
+        }
+    });
+}
+
 
 /**
  * Returns the pusher for events in Redis
@@ -16,6 +39,7 @@ export function getRedisPusher() {
         redisPusher = redis.createClient(Object.assign({}, Config.redis, {
             retry_strategy: getRetryStrategy()
         }));
+        attachPingTimerEvents(redisPusher);
     }
 
     return redisPusher;
@@ -33,6 +57,7 @@ export function getRedisListener({onConnect} = {}) {
             retry_strategy: getRetryStrategy()
         }));
 
+        attachPingTimerEvents(redisListener);
         // we only attach events here
         attachEvents(redisListener, {onConnect});
     }

--- a/lib/utils/getFields.js
+++ b/lib/utils/getFields.js
@@ -1,3 +1,5 @@
+import isNil from "./isNil";
+
 /**
  * Taken from: https://github.com/Meteor-Community-Packages/meteor-collection-hooks/blob/master/collection-hooks.js#L194 and modified.
  * @param mutator
@@ -7,7 +9,7 @@ export default function getFields(mutator) {
     var fields = [];
     var topLevelFields = [];
 
-    Object.entries(mutator).forEach(function ([op, params]) {
+    Object.entries(mutator).filter(([_, params]) => !isNil(params)).forEach(function ([op, params]) {
         if (op[0] == '$') {
             Object.keys(params).forEach(function (field) {
                 // record the field we are trying to change

--- a/lib/utils/isNil.js
+++ b/lib/utils/isNil.js
@@ -1,0 +1,3 @@
+export default function isNil(value) {
+    return value === null || value === undefined;
+}

--- a/lib/utils/testing/getFields.test.js
+++ b/lib/utils/testing/getFields.test.js
@@ -37,4 +37,24 @@ describe('Unit # getFields', function () {
     it('Should properly detected top level fields', function () {
         // TODO
     })
+
+    it('Should ignore null or undefined params', function () {
+        let fields = run({
+            $set: {
+                a: {
+                    d: 1
+                },
+                'profile.test': 1
+            },
+            $inc: {
+                b: 1
+            },
+            $addToSet: undefined
+        }).fields;
+
+        assert.lengthOf(fields, 3);
+        assert.include(fields, 'a');
+        assert.include(fields, 'b');
+        assert.include(fields, 'profile.test');
+    })
 });

--- a/lib/utils/testing/index.js
+++ b/lib/utils/testing/index.js
@@ -1,2 +1,3 @@
 import './getFields.test';
 import './extractIdsFromSelector.test';
+import './isNil.test';

--- a/lib/utils/testing/isNil.test.js
+++ b/lib/utils/testing/isNil.test.js
@@ -1,0 +1,13 @@
+import { assert } from 'chai';
+import run from '../isNil';
+
+describe('Unit # isNil', function () {
+    it('Should work', function () {
+        assert.isTrue(run(null));
+        assert.isTrue(run(undefined));
+        assert.isFalse(run(1));
+        assert.isFalse(run('1'));
+        assert.isFalse(run({}));
+        assert.isFalse(run([]));
+    });
+});

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
-    name: 'cultofcoders:redis-oplog',
-    version: '2.2.1',
+    name: 'networksforchange:redis-oplog',
+    version: '2.2.3',
     // Brief, one-line summary of the package.
     summary: "Replacement for Meteor's MongoDB oplog implementation",
     // URL to the Git repository containing the source code for this package.
@@ -37,7 +37,7 @@ Package.onUse(function(api) {
 });
 
 Package.onTest(function(api) {
-    api.use('cultofcoders:redis-oplog');
+    api.use('networksforchange:redis-oplog');
 
     // extensions
     api.use('aldeed:collection2@3.0.0');


### PR DESCRIPTION
## Why?

Sometimes we have a logic like this:

```js
let $set;

if(someCondition) {
    $set = {
        field: 'value',
    };
}
Collection.update(selector, { $set });
```

The Mongo driver can handle that modifier. It just ignores the `$set` operation when its value is null or undefined.

Fixes: #398 

## Changes

- Ignore operators with null or undefined values
- Added a test case for this scenario
- Added the `isNil` utility function
- Added a test case for the `isNil` utility function