### PR TITLE
Fix URL to Redis configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Configure it via Meteor settings:
 ```
 
 To see what you can configure under `"redis": {}` take a look here:
-https://www.npmjs.com/package/redis#options-object-properties
+https://github.com/redis/node-redis/blob/HEAD/docs/client-configuration.md
 
 ```bash
 meteor run --settings settings.json


### PR DESCRIPTION
I noticed that an URL that was supposed to lead to details about Redis' configuration wasn't working as I expected it to, so I updated it.