### PR TITLE
Fix selection of DEDICATED_CHANNELS strategy

### DIFF
--- a/lib/processors/getStrategy.js
+++ b/lib/processors/getStrategy.js
@@ -1,4 +1,5 @@
-import { Strategy } from "../constants";
+import { Strategy } from '../constants';
+import { _ } from 'meteor/underscore';
 
 /**
  * @param selector
@@ -15,8 +16,13 @@ export default function getStrategy(selector = {}, options = {}) {
     return Strategy.LIMIT_SORT;
   }
 
-  if (selector && selector._id) {
-    return Strategy.DEDICATED_CHANNELS;
+  if (selector && selector._id && _.keys(selector) === 1) {
+    const { _id } = selector;
+
+    if (typeof _id === 'string') return Strategy.DEDICATED_CHANNELS;
+
+    const idOperators = typeof _id === 'object' ? _.keys(_id) : [];
+    if(idOperators.length === 1 && idOperators[0] === '$in') return Strategy.DEDICATED_CHANNELS;
   }
 
   return Strategy.DEFAULT;

--- a/lib/processors/getStrategy.js
+++ b/lib/processors/getStrategy.js
@@ -1,5 +1,5 @@
-import { Strategy } from '../constants';
-import { _ } from 'meteor/underscore';
+import { Strategy } from "../constants";
+import { _ } from "meteor/underscore";
 
 /**
  * @param selector


### PR DESCRIPTION
# Issue
I noticed that the `DEDICATED_CHANNELS` strategy was being selected every time we were querying based on the `_id` field. Most of the time, that's fine. However, this apparently was creating problems when:
- We tried to filter the `_id` field with an operator other than `$in`
- We tried to filter using the `_id` field and another field at the same time

# Solution
I modified the `getStrategy` function. Now it only selects the `DEDICATED_CHANNELS` strategy if both of these are true:
- The only field being used in the query is `_id`
- The `_id` field is either a string or an object with only the `$in` field

This solved all the problems I was having while trying to implement Redis Oplog in my project.

# Notes
I'm a first-time contributor, so I don't know that much about the repo. Please, let me know if you find any problems in my solution and I'll try to improve it.

Also, we're still using Meteor 2.16, and I think the newest versions of Redis oplog aren't compatible with it. It would be great for us if this fix could be made available for versios of Redis Oplog that are compatible with Meteor 2.16. Would that be possible? Let me know if I can help with that.