### PR TITLE
Fix issue with Mongo.Collection.__getCollectionByName not resolving 'users' when used in Meteor 3.1

### DIFF
--- a/lib/cache/ObservableCollection.js
+++ b/lib/cache/ObservableCollection.js
@@ -31,9 +31,7 @@ export default class ObservableCollection {
     this.cursorDescription = cursorDescription;
 
     this.collectionName = this.cursorDescription.collectionName;
-    this.collection = Mongo.Collection.__getCollectionByName(
-      cursorDescription.collectionName
-    );
+    this.collection = Mongo.getCollection(cursorDescription.collectionName);
 
     if (!this.collection) {
       throw new Meteor.Error(


### PR DESCRIPTION
When used in Meteor 3.1, redis-oplog causes crashes because the Meteor "users" collection is not found when calling `Mongo.Collection.__getCollectionByName()`.

This PR fixes it by using the more recent `Meteor.getCollection()` introduced in Meteor 3.0.2